### PR TITLE
Renamed podspec file to ensure pod works without requiring code changes

### DIFF
--- a/TimesSquare.podspec
+++ b/TimesSquare.podspec
@@ -1,11 +1,11 @@
 Pod::Spec.new do |s|
-  s.name         = "objc-TimesSquare"
+  s.name         = "TimesSquare"
   s.version      = "1.0.1"
   s.summary      = "TimesSquare is an Objective-C calendar view for your apps."
   s.homepage     = "https://github.com/square/objc-TimesSquare"
   s.license      = 'Apache License, Version 2.0'
   s.author       = { "Square" => "http://squareup.com" }
-  s.source       = { :git => "https://github.com/square/objc-TimesSquare.git", :branch => "master" }
+  s.source       = { :git => "https://github.com/square/objc-TimesSquare.git", :branch => "master", :tag => s.version.to_s }
   s.platform     = :ios, '5.0'
   s.source_files = 'TimesSquare/*.{h,m}'
   s.requires_arc = true


### PR DESCRIPTION
The existing podspec causes "pod install" to move the sources into objc-TimesSquare which causes TimesSquare.h to fail it's includes. This renames the podspec to what the project is really called and fixes the problem

I Also added version tag to ensure the pod passes pod spec lint
