### PR TITLE
Give a UIAccessibilityTraitSelected to the selectedButton

### DIFF
--- a/TimesSquare/TSQCalendarRowCell.m
+++ b/TimesSquare/TSQCalendarRowCell.m
@@ -102,6 +102,8 @@
     [self.contentView addSubview:self.selectedButton];
     [self configureButton:self.selectedButton];
     
+    [self.selectedButton setAccessibilityTraits:UIAccessibilityTraitSelected|self.selectedButton.accessibilityTraits];
+    
     self.selectedButton.enabled = NO;
     [self.selectedButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
     [self.selectedButton setBackgroundImage:[self selectedBackgroundImage] forState:UIControlStateNormal];


### PR DESCRIPTION
Currently, the selected date is the calendar view doesn't have the UIAccessibilityTraitSelected trait. It affects VoiceOver accessibility and testing using accessibility traits.

This change ensure the selected date always has the UIAccessibilityTraitSelected trait when displayed.
