### PR TITLE
Allow the date to be deselected

### DIFF
--- a/TimesSquare/TSQCalendarView.m
+++ b/TimesSquare/TSQCalendarView.m
@@ -125,46 +125,43 @@
 
 - (void)setSelectedDate:(NSDate *)newSelectedDate;
 {
-    if (newSelectedDate == nil) {
-        [self deselectDate];
-        return;
-    }
-    
     // clamp to beginning of its day
-    NSDate *startOfDay = [self clampDate:newSelectedDate toComponents:NSDayCalendarUnit|NSMonthCalendarUnit|NSYearCalendarUnit];
+    NSDate *startOfDay = nil;
     
-    if ([self.delegate respondsToSelector:@selector(calendarView:shouldSelectDate:)] && ![self.delegate calendarView:self shouldSelectDate:startOfDay]) {
-        return;
+    if (newSelectedDate) {
+        startOfDay = [self clampDate:newSelectedDate toComponents:NSDayCalendarUnit|NSMonthCalendarUnit|NSYearCalendarUnit];
+        
+        if ([self.delegate respondsToSelector:@selector(calendarView:shouldSelectDate:)] && ![self.delegate calendarView:self shouldSelectDate:startOfDay]) {
+            return;
+        }
     }
     
     [[self cellForRowAtDate:_selectedDate] selectColumnForDate:nil];
-    [[self cellForRowAtDate:startOfDay] selectColumnForDate:startOfDay];
-    NSIndexPath *newIndexPath = [self indexPathForRowAtDate:startOfDay];
-    CGRect newIndexPathRect = [self.tableView rectForRowAtIndexPath:newIndexPath];
-    CGRect scrollBounds = self.tableView.bounds;
     
-    if (self.pagingEnabled) {
-        CGRect sectionRect = [self.tableView rectForSection:newIndexPath.section];
-        [self.tableView setContentOffset:sectionRect.origin animated:YES];
-    } else {
-        if (CGRectGetMinY(scrollBounds) > CGRectGetMinY(newIndexPathRect)) {
-            [self.tableView scrollToRowAtIndexPath:newIndexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
-        } else if (CGRectGetMaxY(scrollBounds) < CGRectGetMaxY(newIndexPathRect)) {
-            [self.tableView scrollToRowAtIndexPath:newIndexPath atScrollPosition:UITableViewScrollPositionBottom animated:YES];
+    if (startOfDay) {
+        [[self cellForRowAtDate:startOfDay] selectColumnForDate:startOfDay];
+        
+        NSIndexPath *newIndexPath = [self indexPathForRowAtDate:startOfDay];
+        CGRect newIndexPathRect = [self.tableView rectForRowAtIndexPath:newIndexPath];
+        CGRect scrollBounds = self.tableView.bounds;
+        
+        if (self.pagingEnabled) {
+            CGRect sectionRect = [self.tableView rectForSection:newIndexPath.section];
+            [self.tableView setContentOffset:sectionRect.origin animated:YES];
+        } else {
+            if (CGRectGetMinY(scrollBounds) > CGRectGetMinY(newIndexPathRect)) {
+                [self.tableView scrollToRowAtIndexPath:newIndexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
+            } else if (CGRectGetMaxY(scrollBounds) < CGRectGetMaxY(newIndexPathRect)) {
+                [self.tableView scrollToRowAtIndexPath:newIndexPath atScrollPosition:UITableViewScrollPositionBottom animated:YES];
+            }
         }
     }
     
     _selectedDate = startOfDay;
     
-    if ([self.delegate respondsToSelector:@selector(calendarView:didSelectDate:)]) {
+    if (startOfDay && [self.delegate respondsToSelector:@selector(calendarView:didSelectDate:)]) {
         [self.delegate calendarView:self didSelectDate:startOfDay];
     }
-}
-
-- (void) deselectDate
-{
-    [[self cellForRowAtDate:_selectedDate] selectColumnForDate:nil];
-    _selectedDate = nil;
 }
 
 - (void)scrollToDate:(NSDate *)date animated:(BOOL)animated

--- a/TimesSquare/TSQCalendarView.m
+++ b/TimesSquare/TSQCalendarView.m
@@ -125,6 +125,11 @@
 
 - (void)setSelectedDate:(NSDate *)newSelectedDate;
 {
+    if (newSelectedDate == nil) {
+        [self deselectDate];
+        return;
+    }
+    
     // clamp to beginning of its day
     NSDate *startOfDay = [self clampDate:newSelectedDate toComponents:NSDayCalendarUnit|NSMonthCalendarUnit|NSYearCalendarUnit];
     
@@ -154,6 +159,12 @@
     if ([self.delegate respondsToSelector:@selector(calendarView:didSelectDate:)]) {
         [self.delegate calendarView:self didSelectDate:startOfDay];
     }
+}
+
+- (void) deselectDate
+{
+    [[self cellForRowAtDate:_selectedDate] selectColumnForDate:nil];
+    _selectedDate = nil;
 }
 
 - (void)scrollToDate:(NSDate *)date animated:(BOOL)animated


### PR DESCRIPTION
Currently there is now way to de-select a previously selected date in the calendar. Setting the selectedDate to nil is an error: NSCalendar spits warnings to the console when it attempts to perform date calculations on a nil object.

This commit allows to de-select a date in the calendar by setting selectedDate to nil.
