### PR TITLE
Use rangeOfUnit:inUnit:forDate: to determine the number of weeks in a month

### DIFF
--- a/TimesSquare/TSQCalendarView.m
+++ b/TimesSquare/TSQCalendarView.m
@@ -244,19 +244,8 @@
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section;
 {
     NSDate *firstOfMonth = [self firstOfMonthForSection:section];
-    NSDateComponents *offset = [NSDateComponents new];
-    offset.month = 1;
-    offset.week = -1;
-    offset.day = -1;
-    NSDate *weekBeforeLastOfMonth = [self.calendar dateByAddingComponents:offset toDate:firstOfMonth options:0];
-
-    NSInteger firstWeek = [self.calendar components:NSWeekOfYearCalendarUnit fromDate:firstOfMonth].weekOfYear;
-
-    // -[NSDateComponents weekOfYear] doesn't explicitly specify what its valid range is. In the Gregorian case, it appears to be [1,52], which means the last day of December is probably going to be week 1 of next year. The same logic extends to other calendars.
-    // To account for the wrap, we simply go a week earlier and add one to the difference.
-    NSInteger nextToLastWeek = [self.calendar components:NSWeekOfYearCalendarUnit fromDate:weekBeforeLastOfMonth].weekOfYear;
-    
-    return (self.pinsHeaderToTop ? 2 : 3) + nextToLastWeek - firstWeek;
+    NSRange rangeOfWeeks = [self.calendar rangeOfUnit:NSWeekCalendarUnit inUnit:NSMonthCalendarUnit forDate:firstOfMonth];
+    return (self.pinsHeaderToTop ? 0 : 1) + rangeOfWeeks.length;
 }
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath;


### PR DESCRIPTION
This fixes issue #18 by using <a href="https://developer.apple.com/library/ios/documentation/Cocoa/Reference/Foundation/Classes/NSCalendar_Class/Reference/NSCalendar.html#//apple_ref/doc/uid/TP40001451-BBCDBDDG">`-[NSCalendar rangeOfUnit:inUnit:forDate:]`</a> to determine the number of weeks instead of examining the week number of particular weeks, which failed for UK dates (which can have a week number of 53)
