### PR TITLE
Use NSWeekOfMonthCalendarUnit not NSWeekOfYearCalendarUnit

### DIFF
--- a/TimesSquare/TSQCalendarView.m
+++ b/TimesSquare/TSQCalendarView.m
@@ -194,14 +194,13 @@
     if (!date) {
         return nil;
     }
-
+    
     NSInteger section = [self sectionForDate:date];
     NSDate *firstOfMonth = [self firstOfMonthForSection:section];
-    NSInteger firstWeek = [self.calendar components:NSWeekOfYearCalendarUnit fromDate:firstOfMonth].weekOfYear;
-    NSInteger targetWeek = [self.calendar components:NSWeekOfYearCalendarUnit fromDate:date].weekOfYear;
-    if (targetWeek < firstWeek) {
-        targetWeek = [self.calendar maximumRangeOfUnit:NSWeekOfYearCalendarUnit].length;
-    }
+    
+    NSInteger firstWeek = [self.calendar components:NSWeekOfMonthCalendarUnit fromDate:firstOfMonth].weekOfMonth;
+    NSInteger targetWeek = [self.calendar components:NSWeekOfMonthCalendarUnit fromDate:date].weekOfMonth;
+    
     return [NSIndexPath indexPathForRow:(self.pinsHeaderToTop ? 0 : 1) + targetWeek - firstWeek inSection:section];
 }
 


### PR DESCRIPTION
The selection wasn't showing in January 2012 in the en_GB locale for the 3rd and subsequent weeks of the month.  This was due to `-indexPathForRowAtDate:` using NSWeekOfYearCalendarUnit which behaves differently in en_GB to en_US. This fixes the issue by using NSWeekOfMonthCalendarUnit instead.
