### PR TITLE
Show an event marker for particular dates

### DIFF
--- a/TimesSquare.xcodeproj/project.pbxproj
+++ b/TimesSquare.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		EFD8DE6F167AF78600F87FBE /* TSQCalendarMonthHeaderCell.h in Headers */ = {isa = PBXBuildFile; fileRef = A8068088167010030071C71E /* TSQCalendarMonthHeaderCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EFD8DE70167AF78C00F87FBE /* TSQCalendarRowCell.h in Headers */ = {isa = PBXBuildFile; fileRef = A806808A167010030071C71E /* TSQCalendarRowCell.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		EFD8DE71167AF79000F87FBE /* TSQCalendarView.h in Headers */ = {isa = PBXBuildFile; fileRef = A806808C167010030071C71E /* TSQCalendarView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F6C9C449173D29C3004EA826 /* TSQCalendarRowButton.h in Headers */ = {isa = PBXBuildFile; fileRef = F6C9C447173D29C3004EA826 /* TSQCalendarRowButton.h */; };
+		F6C9C44A173D29C3004EA826 /* TSQCalendarRowButton.m in Sources */ = {isa = PBXBuildFile; fileRef = F6C9C448173D29C3004EA826 /* TSQCalendarRowButton.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -48,6 +50,8 @@
 		A806808C167010030071C71E /* TSQCalendarView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSQCalendarView.h; sourceTree = "<group>"; };
 		A806808D167010030071C71E /* TSQCalendarView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSQCalendarView.m; sourceTree = "<group>"; };
 		A806809E167012980071C71E /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		F6C9C447173D29C3004EA826 /* TSQCalendarRowButton.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TSQCalendarRowButton.h; sourceTree = "<group>"; };
+		F6C9C448173D29C3004EA826 /* TSQCalendarRowButton.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TSQCalendarRowButton.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -99,6 +103,8 @@
 				A8068087167010030071C71E /* TSQCalendarCell.m */,
 				A8068088167010030071C71E /* TSQCalendarMonthHeaderCell.h */,
 				A8068089167010030071C71E /* TSQCalendarMonthHeaderCell.m */,
+				F6C9C447173D29C3004EA826 /* TSQCalendarRowButton.h */,
+				F6C9C448173D29C3004EA826 /* TSQCalendarRowButton.m */,
 				A806808A167010030071C71E /* TSQCalendarRowCell.h */,
 				A806808B167010030071C71E /* TSQCalendarRowCell.m */,
 				A806808C167010030071C71E /* TSQCalendarView.h */,
@@ -128,6 +134,7 @@
 				EFD8DE6F167AF78600F87FBE /* TSQCalendarMonthHeaderCell.h in Headers */,
 				EFD8DE70167AF78C00F87FBE /* TSQCalendarRowCell.h in Headers */,
 				EFD8DE71167AF79000F87FBE /* TSQCalendarView.h in Headers */,
+				F6C9C449173D29C3004EA826 /* TSQCalendarRowButton.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -205,6 +212,7 @@
 				A8068090167010030071C71E /* TSQCalendarMonthHeaderCell.m in Sources */,
 				A8068092167010030071C71E /* TSQCalendarRowCell.m in Sources */,
 				A8068094167010030071C71E /* TSQCalendarView.m in Sources */,
+				F6C9C44A173D29C3004EA826 /* TSQCalendarRowButton.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/TimesSquare/TSQCalendarRowButton.h
+++ b/TimesSquare/TSQCalendarRowButton.h
@@ -1,0 +1,26 @@
+//
+//  TSQCalendarButton.h
+//  TimesSquare
+//
+//  Created by Simon Booth on 10/05/2013.
+//  Licensed to Square, Inc. under one or more contributor license agreements.
+//  See the LICENSE file distributed with this work for the terms under
+//  which Square, Inc. licenses this file to you.
+
+
+#import <UIKit/UIKit.h>
+
+/** The `TSQCalendarRowButton` class is a button that represents single day in the calendar.
+ 
+ The button contains an additional label which is used to display an event marker.
+ */
+@interface TSQCalendarRowButton : UIButton
+
+/** A label used to display an event marker
+ 
+ The marker is shown using the bullet character '•'
+ 
+ */
+@property (nonatomic, strong, readonly) UILabel *subtitleLabel;
+
+@end

--- a/TimesSquare/TSQCalendarRowButton.h
+++ b/TimesSquare/TSQCalendarRowButton.h
@@ -9,6 +9,7 @@
 
 
 #import <UIKit/UIKit.h>
+#import "TSQCalendarRowCell.h"
 
 /** The `TSQCalendarRowButton` class is a button that represents single day in the calendar.
  
@@ -22,5 +23,12 @@
  
  */
 @property (nonatomic, strong, readonly) UILabel *subtitleLabel;
+
+/** Configures the button according to the given row's properties
+
+ The button is set up using the text color and shadow offset of the row
+ 
+ */
+- (void)configureWithRowCell:(TSQCalendarRowCell *)rowCell;
 
 @end

--- a/TimesSquare/TSQCalendarRowButton.m
+++ b/TimesSquare/TSQCalendarRowButton.m
@@ -1,0 +1,76 @@
+//
+//  TSQCalendarButton.m
+//  TimesSquare
+//
+//  Created by Simon Booth on 10/05/2013.
+//  Licensed to Square, Inc. under one or more contributor license agreements.
+//  See the LICENSE file distributed with this work for the terms under
+//  which Square, Inc. licenses this file to you.
+
+#import "TSQCalendarRowButton.h"
+
+
+@implementation TSQCalendarRowButton
+
+- (id)initWithFrame:(CGRect)frame
+{
+    self = [super initWithFrame:frame];
+    if (self)
+    {
+        self.titleLabel.font = [UIFont boldSystemFontOfSize:19.f];
+        self.adjustsImageWhenDisabled = NO;
+        [self setTitleShadowColor:[UIColor whiteColor] forState:UIControlStateNormal];
+        
+        _subtitleLabel = [[UILabel alloc] init];
+        _subtitleLabel.backgroundColor = [UIColor clearColor];
+        _subtitleLabel.textAlignment = UITextAlignmentCenter;
+        [self addSubview:_subtitleLabel];
+        
+        [self updateSubtitleLabel];
+    }
+    return self;
+}
+
+- (void)layoutSubviews
+{
+    [super layoutSubviews];
+
+    CGRect subtitleFrame = self.bounds;
+    subtitleFrame.origin.y = subtitleFrame.size.height - 15;
+    subtitleFrame.size.height = 15;
+    self.subtitleLabel.frame = subtitleFrame;
+}
+
+- (void)updateSubtitleLabel
+{
+    self.subtitleLabel.font = self.titleLabel.font;
+    self.subtitleLabel.textColor = self.currentTitleColor;
+    self.subtitleLabel.shadowColor = self.currentTitleShadowColor;
+    self.subtitleLabel.shadowOffset = self.titleLabel.shadowOffset;
+}
+
+- (void)setTitleShadowColor:(UIColor *)color forState:(UIControlState)state
+{
+    [super setTitleShadowColor:color forState:state];
+    [self updateSubtitleLabel];
+}
+
+- (void)setTitleColor:(UIColor *)color forState:(UIControlState)state
+{
+    [super setTitleColor:color forState:state];
+    [self updateSubtitleLabel];
+}
+
+- (void)setHighlighted:(BOOL)highlighted
+{
+    [super setHighlighted:highlighted];
+    [self updateSubtitleLabel];
+}
+
+- (void)setSelected:(BOOL)selected
+{
+    [super setSelected:selected];
+    [self updateSubtitleLabel];
+}
+
+@end

--- a/TimesSquare/TSQCalendarRowButton.m
+++ b/TimesSquare/TSQCalendarRowButton.m
@@ -23,12 +23,20 @@
         
         _subtitleLabel = [[UILabel alloc] init];
         _subtitleLabel.backgroundColor = [UIColor clearColor];
+        _subtitleLabel.font = self.titleLabel.font;
         _subtitleLabel.textAlignment = UITextAlignmentCenter;
         [self addSubview:_subtitleLabel];
         
         [self updateSubtitleLabel];
     }
     return self;
+}
+
+- (void)configureWithRowCell:(TSQCalendarRowCell *)rowCell
+{
+    [self setTitleColor:rowCell.textColor forState:UIControlStateNormal];
+    self.titleLabel.shadowOffset = rowCell.shadowOffset;
+    [self updateSubtitleLabel];
 }
 
 - (void)layoutSubviews
@@ -43,7 +51,6 @@
 
 - (void)updateSubtitleLabel
 {
-    self.subtitleLabel.font = self.titleLabel.font;
     self.subtitleLabel.textColor = self.currentTitleColor;
     self.subtitleLabel.shadowColor = self.currentTitleShadowColor;
     self.subtitleLabel.shadowOffset = self.titleLabel.shadowOffset;

--- a/TimesSquare/TSQCalendarRowButton.m
+++ b/TimesSquare/TSQCalendarRowButton.m
@@ -12,11 +12,10 @@
 
 @implementation TSQCalendarRowButton
 
-- (id)initWithFrame:(CGRect)frame
+- (id)initWithFrame:(CGRect)frame;
 {
     self = [super initWithFrame:frame];
-    if (self)
-    {
+    if (self) {
         self.titleLabel.font = [UIFont boldSystemFontOfSize:19.f];
         self.adjustsImageWhenDisabled = NO;
         [self setTitleShadowColor:[UIColor whiteColor] forState:UIControlStateNormal];
@@ -32,14 +31,14 @@
     return self;
 }
 
-- (void)configureWithRowCell:(TSQCalendarRowCell *)rowCell
+- (void)configureWithRowCell:(TSQCalendarRowCell *)rowCell;
 {
     [self setTitleColor:rowCell.textColor forState:UIControlStateNormal];
     self.titleLabel.shadowOffset = rowCell.shadowOffset;
     [self updateSubtitleLabel];
 }
 
-- (void)layoutSubviews
+- (void)layoutSubviews;
 {
     [super layoutSubviews];
 
@@ -49,32 +48,32 @@
     self.subtitleLabel.frame = subtitleFrame;
 }
 
-- (void)updateSubtitleLabel
+- (void)updateSubtitleLabel;
 {
     self.subtitleLabel.textColor = self.currentTitleColor;
     self.subtitleLabel.shadowColor = self.currentTitleShadowColor;
     self.subtitleLabel.shadowOffset = self.titleLabel.shadowOffset;
 }
 
-- (void)setTitleShadowColor:(UIColor *)color forState:(UIControlState)state
+- (void)setTitleShadowColor:(UIColor *)color forState:(UIControlState)state;
 {
     [super setTitleShadowColor:color forState:state];
     [self updateSubtitleLabel];
 }
 
-- (void)setTitleColor:(UIColor *)color forState:(UIControlState)state
+- (void)setTitleColor:(UIColor *)color forState:(UIControlState)state;
 {
     [super setTitleColor:color forState:state];
     [self updateSubtitleLabel];
 }
 
-- (void)setHighlighted:(BOOL)highlighted
+- (void)setHighlighted:(BOOL)highlighted;
 {
     [super setHighlighted:highlighted];
     [self updateSubtitleLabel];
 }
 
-- (void)setSelected:(BOOL)selected
+- (void)setSelected:(BOOL)selected;
 {
     [super setSelected:selected];
     [self updateSubtitleLabel];

--- a/TimesSquare/TSQCalendarRowCell.h
+++ b/TimesSquare/TSQCalendarRowCell.h
@@ -65,4 +65,12 @@
  */
 - (void)selectColumnForDate:(NSDate *)date;
 
+/** @name Button configuration */
+
+/** The button class to use for day buttons.
+ 
+ The class should be a subclass of `TSQCalendarRowButton` or at least implement all of its methods.
+ */
+@property (nonatomic, strong) Class rowButtonClass;
+
 @end

--- a/TimesSquare/TSQCalendarRowCell.m
+++ b/TimesSquare/TSQCalendarRowCell.m
@@ -42,22 +42,23 @@
     return self;
 }
 
-- (void)configureButton:(TSQCalendarRowButton *)button;
+- (Class)rowButtonClass;
 {
-    button.titleLabel.shadowOffset = self.shadowOffset;
-    [button setTitleColor:self.textColor forState:UIControlStateNormal];
-    button.subtitleLabel.shadowOffset = self.shadowOffset;
+    if (!_rowButtonClass) {
+        self.rowButtonClass = [TSQCalendarRowButton class];
+    }
+    return _rowButtonClass;
 }
 
 - (void)createDayButtons;
 {
     NSMutableArray *dayButtons = [NSMutableArray arrayWithCapacity:self.daysInWeek];
     for (NSUInteger index = 0; index < self.daysInWeek; index++) {
-        TSQCalendarRowButton *button = [[TSQCalendarRowButton alloc] initWithFrame:self.contentView.bounds];
+        TSQCalendarRowButton *button = [[self.rowButtonClass alloc] initWithFrame:self.contentView.bounds];
         [button addTarget:self action:@selector(dateButtonPressed:) forControlEvents:UIControlEventTouchDown];
         [dayButtons addObject:button];
         [self.contentView addSubview:button];
-        [self configureButton:button];
+        [button configureWithRowCell:self];
         [button setTitleColor:[self.textColor colorWithAlphaComponent:0.5f] forState:UIControlStateDisabled];
     }
     self.dayButtons = dayButtons;
@@ -67,10 +68,10 @@
 {
     NSMutableArray *notThisMonthButtons = [NSMutableArray arrayWithCapacity:self.daysInWeek];
     for (NSUInteger index = 0; index < self.daysInWeek; index++) {
-        TSQCalendarRowButton *button = [[TSQCalendarRowButton alloc] initWithFrame:self.contentView.bounds];
+        TSQCalendarRowButton *button = [[self.rowButtonClass alloc] initWithFrame:self.contentView.bounds];
         [notThisMonthButtons addObject:button];
         [self.contentView addSubview:button];
-        [self configureButton:button];
+        [button configureWithRowCell:self];
 
         button.enabled = NO;
         UIColor *backgroundPattern = [UIColor colorWithPatternImage:[self notThisMonthBackgroundImage]];
@@ -82,9 +83,9 @@
 
 - (void)createTodayButton;
 {
-    self.todayButton = [[TSQCalendarRowButton alloc] initWithFrame:self.contentView.bounds];
+    self.todayButton = [[self.rowButtonClass alloc] initWithFrame:self.contentView.bounds];
     [self.contentView addSubview:self.todayButton];
-    [self configureButton:self.todayButton];
+    [self.todayButton configureWithRowCell:self];
     [self.todayButton addTarget:self action:@selector(todayButtonPressed:) forControlEvents:UIControlEventTouchDown];
     
     [self.todayButton setTitleColor:[UIColor whiteColor] forState:UIControlStateNormal];
@@ -96,9 +97,9 @@
 
 - (void)createSelectedButton;
 {
-    self.selectedButton = [[TSQCalendarRowButton alloc] initWithFrame:self.contentView.bounds];
+    self.selectedButton = [[self.rowButtonClass alloc] initWithFrame:self.contentView.bounds];
     [self.contentView addSubview:self.selectedButton];
-    [self configureButton:self.selectedButton];
+    [self.selectedButton configureWithRowCell:self];
     
     [self.selectedButton setAccessibilityTraits:UIAccessibilityTraitSelected|self.selectedButton.accessibilityTraits];
     

--- a/TimesSquare/TSQCalendarView.h
+++ b/TimesSquare/TSQCalendarView.h
@@ -104,6 +104,15 @@
  */
 - (void)scrollToDate:(NSDate *)date animated:(BOOL)animated;
 
+/** Whether a particular date should display an event marker
+ 
+ This method passes straight through to the delegate
+ 
+ @param date The date being displayed.
+ @return Whether or not the date should display an event marker.
+ */
+- (BOOL)shouldDisplayEventMarkerForDate:(NSDate *)date;
+
 @end
 
 /** The methods in the `TSQCalendarViewDelegate` protocol allow the adopting delegate to either prevent a day from being selected or respond to it.
@@ -130,5 +139,15 @@
  @param date Midnight on the date being selected.
  */
 - (void)calendarView:(TSQCalendarView *)calendarView didSelectDate:(NSDate *)date;
+
+/** @name Displaying event markers */
+
+/** Asks the delegate whether a particular date should display an event marker
+ 
+ @param calendarView The calendar view that is displaying a date.
+ @param date The date being displayed.
+ @return Whether or not the date should display an event marker.
+ */
+- (BOOL)calendarView:(TSQCalendarView *)calendarView shouldDisplayEventMarkerForDate:(NSDate *)date;
 
 @end

--- a/TimesSquare/TSQCalendarView.m
+++ b/TimesSquare/TSQCalendarView.m
@@ -162,6 +162,16 @@
   [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section] atScrollPosition:UITableViewScrollPositionTop animated:animated];
 }
 
+- (BOOL)shouldDisplayEventMarkerForDate:(NSDate *)date
+{
+    if ([self.delegate respondsToSelector:@selector(calendarView:shouldDisplayEventMarkerForDate:)])
+    {
+        return [self.delegate calendarView:self shouldDisplayEventMarkerForDate:date];
+    }
+    
+    return NO;
+}
+
 - (TSQCalendarMonthHeaderCell *)makeHeaderCellWithIdentifier:(NSString *)identifier;
 {
     TSQCalendarMonthHeaderCell *cell = [[[self headerCellClass] alloc] initWithCalendar:self.calendar reuseIdentifier:identifier];

--- a/TimesSquare/TSQCalendarView.m
+++ b/TimesSquare/TSQCalendarView.m
@@ -162,10 +162,9 @@
   [self.tableView scrollToRowAtIndexPath:[NSIndexPath indexPathForRow:0 inSection:section] atScrollPosition:UITableViewScrollPositionTop animated:animated];
 }
 
-- (BOOL)shouldDisplayEventMarkerForDate:(NSDate *)date
+- (BOOL)shouldDisplayEventMarkerForDate:(NSDate *)date;
 {
-    if ([self.delegate respondsToSelector:@selector(calendarView:shouldDisplayEventMarkerForDate:)])
-    {
+    if ([self.delegate respondsToSelector:@selector(calendarView:shouldDisplayEventMarkerForDate:)]) {
         return [self.delegate calendarView:self shouldDisplayEventMarkerForDate:date];
     }
     

--- a/TimesSquareTestApp/TSQTAViewController.m
+++ b/TimesSquareTestApp/TSQTAViewController.m
@@ -12,7 +12,7 @@
 #import <TimesSquare/TimesSquare.h>
 
 
-@interface TSQTAViewController ()
+@interface TSQTAViewController () <TSQCalendarViewDelegate>
 
 @property (nonatomic, retain) NSTimer *timer;
 
@@ -39,6 +39,7 @@
     calendarView.pagingEnabled = YES;
     CGFloat onePixel = 1.0f / [UIScreen mainScreen].scale;
     calendarView.contentInset = UIEdgeInsetsMake(0.0f, onePixel, 0.0f, onePixel);
+    calendarView.delegate = self;
 
     self.view = calendarView;
 }
@@ -79,6 +80,14 @@
     
     [tableView setContentOffset:CGPointMake(0.f, atTop ? 10000.f : 0.f) animated:YES];
     atTop = !atTop;
+}
+
+- (BOOL)calendarView:(TSQCalendarView *)calendarView shouldDisplayEventMarkerForDate:(NSDate *)date
+{
+    NSDateComponents *components = [calendarView.calendar components:NSMonthCalendarUnit|NSDayCalendarUnit fromDate:date];
+    
+    // This gives a nice pattern
+    return (components.day%9 == components.month%9) || (components.day%11 == components.month%11);
 }
 
 @end

--- a/TimesSquareTestApp/TSQTAViewController.m
+++ b/TimesSquareTestApp/TSQTAViewController.m
@@ -82,12 +82,12 @@
     atTop = !atTop;
 }
 
-- (BOOL)calendarView:(TSQCalendarView *)calendarView shouldDisplayEventMarkerForDate:(NSDate *)date
+- (BOOL)calendarView:(TSQCalendarView *)calendarView shouldDisplayEventMarkerForDate:(NSDate *)date;
 {
     NSDateComponents *components = [calendarView.calendar components:NSMonthCalendarUnit|NSDayCalendarUnit fromDate:date];
     
     // This gives a nice pattern
-    return (components.day%9 == components.month%9) || (components.day%11 == components.month%11);
+    return (components.day % 9 == components.month % 9) || (components.day % 11 == components.month % 11);
 }
 
 @end


### PR DESCRIPTION
This adds a method to the calendar delegate, `-calendarView:shouldDisplayEventMarkerForDate:`, which allows the delegate to specify that a marker should be displayed under the number.

![screen shot 2013-05-10 at 15 11 06](https://f.cloud.github.com/assets/301674/488312/7e7674f0-b97b-11e2-8f8a-068e89eeb948.png)

The marker is the bullet character '•' so no additional images are required, and the delegate method is optional so this shouldn't break any existing installations.
