### PR TITLE
iOS 7 doesn’t call -layoutSubviews when a cell is created like iOS 6 did...

### DIFF
--- a/TimesSquare/TSQCalendarRowCell.m
+++ b/TimesSquare/TSQCalendarRowCell.m
@@ -117,6 +117,13 @@
 {
     _beginningDate = date;
     
+    if (!self.dayButtons) {
+        [self createDayButtons];
+        [self createNotThisMonthButtons];
+        [self createTodayButton];
+        [self createSelectedButton];
+    }
+
     NSDateComponents *offset = [NSDateComponents new];
     offset.day = 1;
 
@@ -191,13 +198,6 @@
 
 - (void)layoutSubviews;
 {
-    if (!self.dayButtons) {
-        [self createDayButtons];
-        [self createNotThisMonthButtons];
-        [self createTodayButton];
-        [self createSelectedButton];
-    }
-    
     if (!self.backgroundView) {
         [self setBottomRow:NO];
     }


### PR DESCRIPTION
.... Find a better place to create the cell’s subviews.

Fixes #29.
