### PR TITLE
Option to snap scrolling to the nearest row boundary

### DIFF
--- a/TimesSquare/TSQCalendarView.h
+++ b/TimesSquare/TSQCalendarView.h
@@ -71,6 +71,13 @@
  */
 @property (nonatomic) BOOL pagingEnabled;
 
+/** Whether or not the calendar snaps the nearest edge of a row to the top of its bounds.
+ 
+ This property is similar to `pagingEnabled`, except the snapping is to rows rather than months.
+ Paging takes precedence over snapping to row boundaries.
+ */
+@property (nonatomic) BOOL snapsToRows;
+
 /** The distance from the edges of the view to where the content begins.
  
  This property is equivalent to the one defined on `UIScrollView`.

--- a/TimesSquare/TSQCalendarView.m
+++ b/TimesSquare/TSQCalendarView.m
@@ -307,6 +307,16 @@
         }
         CGRect sectionRect = [self.tableView rectForSection:section];
         *targetContentOffset = sectionRect.origin;
+    } else if (self.snapsToRows) {
+        // Find the frame of the cell the scroll will end in
+        NSIndexPath *targetIndexPath = [self.tableView indexPathForRowAtPoint:*targetContentOffset];
+        CGRect targetCellRect = [self.tableView rectForRowAtIndexPath:targetIndexPath];
+        // Round the scroll finish point to the nearest cell boundary
+        if (targetContentOffset->y < targetCellRect.origin.y + targetCellRect.size.height/2.) {
+            targetContentOffset->y = targetCellRect.origin.y;
+        } else {
+            targetContentOffset->y = targetCellRect.origin.y + targetCellRect.size.height;
+        }
     }
 }
 


### PR DESCRIPTION
Added `@property (nonatomic) BOOL snapsToRows;` to enable snapping the nearest edge of a row to the top of the calendar when scrolling ends.
This property is similar to `pagingEnabled`, except the snapping is to rows rather than months.
Paging takes precedence over snapping to row boundaries.
